### PR TITLE
Show full player after Play button

### DIFF
--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
     @Environment(\.nowPlayingExpandProgress) var expandProgress
+    @Environment(NowPlayingController.self) var player
+    @Environment(\.presentNowPlaying) var presentNowPlaying
 
     var body: some View {
         NavigationStack {
@@ -81,7 +83,8 @@ private extension MediaListView {
     var buttons: some View {
         HStack(spacing: 16) {
             Button {
-                print("Play")
+                player.onPlayPause()
+                presentNowPlaying?()
             }
             label: {
                 Label("Play", systemImage: "play.fill")

--- a/AppleMusicStylePlayer/NowPlaying/NowPlayingPresenter.swift
+++ b/AppleMusicStylePlayer/NowPlaying/NowPlayingPresenter.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+private struct PresentNowPlayingEnvironmentKey: EnvironmentKey {
+    static let defaultValue: (() -> Void)? = nil
+}
+
+extension EnvironmentValues {
+    var presentNowPlaying: (() -> Void)? {
+        get { self[PresentNowPlayingEnvironmentKey.self] }
+        set { self[PresentNowPlayingEnvironmentKey.self] = newValue }
+    }
+}
+

--- a/AppleMusicStylePlayer/OverlaidRootView.swift
+++ b/AppleMusicStylePlayer/OverlaidRootView.swift
@@ -32,6 +32,10 @@ struct OverlaidRootView: View {
         }
         .environment(playerController)
         .environment(playlistController)
+        .environment(\.presentNowPlaying, {
+            showOverlayingNowPlayng = true
+            expandedNowPlaying = true
+        })
         .universalOverlay(animation: .none, show: $showOverlayingNowPlayng) {
             ExpandableNowPlaying(
                 show: $showOverlayingNowPlayng,


### PR DESCRIPTION
## Summary
- add environment key for controlling Now Playing presentation
- expose `presentNowPlaying` in `OverlaidRootView`
- open full Now Playing from the MediaList "Play" button

## Testing
- `swift build -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685e6cccd64c8329aa25e74e7a71631a