### PR TITLE
Expand player after play button tap

### DIFF
--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
+    @Environment(NowPlayingController.self) var nowPlaying
+    @Environment(\.nowPlayingExpandAction) var expandNowPlaying
     @Environment(\.nowPlayingExpandProgress) var expandProgress
 
     var body: some View {
@@ -81,9 +83,9 @@ private extension MediaListView {
     var buttons: some View {
         HStack(spacing: 16) {
             Button {
-                print("Play")
-            }
-            label: {
+                nowPlaying.onPlayPause()
+                expandNowPlaying()
+            } label: {
                 Label("Play", systemImage: "play.fill")
             }
 

--- a/AppleMusicStylePlayer/NowPlaying/CompactNowPlaying.swift
+++ b/AppleMusicStylePlayer/NowPlaying/CompactNowPlaying.swift
@@ -33,6 +33,9 @@ struct CompactNowPlaying: View {
                 },
                 onEnded: {
                     model.onPlayPause()
+                    withAnimation(.playerExpandAnimation) {
+                        expanded = true
+                    }
                 }
             )
             .playerButtonStyle(.miniPlayer)

--- a/AppleMusicStylePlayer/NowPlaying/NowPlayingExpandAction.swift
+++ b/AppleMusicStylePlayer/NowPlaying/NowPlayingExpandAction.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct NowPlayingExpandActionKey: EnvironmentKey {
+    static let defaultValue: () -> Void = {}
+}
+
+extension EnvironmentValues {
+    var nowPlayingExpandAction: () -> Void {
+        get { self[NowPlayingExpandActionKey.self] }
+        set { self[NowPlayingExpandActionKey.self] = newValue }
+    }
+}

--- a/AppleMusicStylePlayer/OverlaidRootView.swift
+++ b/AppleMusicStylePlayer/OverlaidRootView.swift
@@ -43,6 +43,11 @@ struct OverlaidRootView: View {
             }
         }
         .environment(\.nowPlayingExpandProgress, nowPlayingExpandProgress)
+        .environment(\.nowPlayingExpandAction) {
+            withAnimation(.playerExpandAnimation) {
+                expandedNowPlaying = true
+            }
+        }
     }
 
     func showNowPlayng(replacement: Bool) {


### PR DESCRIPTION
## Summary
- ensure tapping Play in MediaList starts playback and expands the Now Playing view
- wire up environment closure so any view can trigger expansion

## Testing
- `swiftlint` *(fails: command not found)*
- `swiftformat --lint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6ee13178832984a1bdc3234705e5