### PR TITLE
Enable expanding player after pressing Play

### DIFF
--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
+    @Environment(NowPlayingController.self) var player
+    @Environment(\.nowPlayingExpandedBinding) var expandedBinding
     @Environment(\.nowPlayingExpandProgress) var expandProgress
 
     var body: some View {
@@ -81,9 +83,9 @@ private extension MediaListView {
     var buttons: some View {
         HStack(spacing: 16) {
             Button {
-                print("Play")
-            }
-            label: {
+                player.onPlayPause()
+                expandedBinding?.wrappedValue = true
+            } label: {
                 Label("Play", systemImage: "play.fill")
             }
 

--- a/AppleMusicStylePlayer/NowPlaying/CompactNowPlaying.swift
+++ b/AppleMusicStylePlayer/NowPlaying/CompactNowPlaying.swift
@@ -33,6 +33,11 @@ struct CompactNowPlaying: View {
                 },
                 onEnded: {
                     model.onPlayPause()
+                    if model.state == .playing {
+                        withAnimation(.playerExpandAnimation) {
+                            expanded = true
+                        }
+                    }
                 }
             )
             .playerButtonStyle(.miniPlayer)

--- a/AppleMusicStylePlayer/NowPlaying/NowPlayingExpandTracking.swift
+++ b/AppleMusicStylePlayer/NowPlaying/NowPlayingExpandTracking.swift
@@ -23,4 +23,13 @@ extension EnvironmentValues {
         get { self[NowPlayingExpandProgressEnvironmentKey.self] }
         set { self[NowPlayingExpandProgressEnvironmentKey.self] = newValue }
     }
+
+    var nowPlayingExpandedBinding: Binding<Bool>? {
+        get { self[NowPlayingExpandedBindingKey.self] }
+        set { self[NowPlayingExpandedBindingKey.self] = newValue }
+    }
+}
+
+private struct NowPlayingExpandedBindingKey: EnvironmentKey {
+    static let defaultValue: Binding<Bool>? = nil
 }

--- a/AppleMusicStylePlayer/OverlaidRootView.swift
+++ b/AppleMusicStylePlayer/OverlaidRootView.swift
@@ -32,6 +32,7 @@ struct OverlaidRootView: View {
         }
         .environment(playerController)
         .environment(playlistController)
+        .environment(\.nowPlayingExpandedBinding, $expandedNowPlaying)
         .universalOverlay(animation: .none, show: $showOverlayingNowPlayng) {
             ExpandableNowPlaying(
                 show: $showOverlayingNowPlayng,


### PR DESCRIPTION
## Summary
- propagate binding for controlling player expansion through environment
- expand player when hitting Play in the media list
- expand player when using mini-player play button

## Testing
- `swiftc -typecheck AppleMusicStylePlayer/NowPlaying/NowPlayingExpandTracking.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685e74bb8284832984ec2afac4ecf63f