### PR TITLE
Enable full screen player from start page play button

### DIFF
--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
     @Environment(\.nowPlayingExpandProgress) var expandProgress
+    @Environment(NowPlayingController.self) var player
+    @Environment(\.expandNowPlaying) var expandNowPlaying
 
     var body: some View {
         NavigationStack {
@@ -81,7 +83,8 @@ private extension MediaListView {
     var buttons: some View {
         HStack(spacing: 16) {
             Button {
-                print("Play")
+                player.onPlayPause()
+                expandNowPlaying()
             }
             label: {
                 Label("Play", systemImage: "play.fill")

--- a/AppleMusicStylePlayer/NowPlaying/NowPlayingActions.swift
+++ b/AppleMusicStylePlayer/NowPlaying/NowPlayingActions.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
+typealias ExpandNowPlayingAction = @MainActor () -> Void
+
 private struct ExpandNowPlayingKey: EnvironmentKey {
-    static let defaultValue: () -> Void = {}
+    static let defaultValue: ExpandNowPlayingAction = {}
 }
 
 extension EnvironmentValues {
-    var expandNowPlaying: () -> Void {
+    var expandNowPlaying: ExpandNowPlayingAction {
         get { self[ExpandNowPlayingKey.self] }
         set { self[ExpandNowPlayingKey.self] = newValue }
     }

--- a/AppleMusicStylePlayer/NowPlaying/NowPlayingActions.swift
+++ b/AppleMusicStylePlayer/NowPlaying/NowPlayingActions.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct ExpandNowPlayingKey: EnvironmentKey {
+    static let defaultValue: () -> Void = {}
+}
+
+extension EnvironmentValues {
+    var expandNowPlaying: () -> Void {
+        get { self[ExpandNowPlayingKey.self] }
+        set { self[ExpandNowPlayingKey.self] = newValue }
+    }
+}

--- a/AppleMusicStylePlayer/NowPlaying/NowPlayingActions.swift
+++ b/AppleMusicStylePlayer/NowPlaying/NowPlayingActions.swift
@@ -3,7 +3,7 @@ import SwiftUI
 typealias ExpandNowPlayingAction = @MainActor () -> Void
 
 private struct ExpandNowPlayingKey: EnvironmentKey {
-    static let defaultValue: ExpandNowPlayingAction = {}
+    @MainActor static let defaultValue: ExpandNowPlayingAction = {}
 }
 
 extension EnvironmentValues {

--- a/AppleMusicStylePlayer/OverlaidRootView.swift
+++ b/AppleMusicStylePlayer/OverlaidRootView.swift
@@ -32,6 +32,12 @@ struct OverlaidRootView: View {
         }
         .environment(playerController)
         .environment(playlistController)
+        .environment(\.expandNowPlaying) {
+            withAnimation(.playerExpandAnimation) {
+                showOverlayingNowPlayng = true
+                expandedNowPlaying = true
+            }
+        }
         .universalOverlay(animation: .none, show: $showOverlayingNowPlayng) {
             ExpandableNowPlaying(
                 show: $showOverlayingNowPlayng,
@@ -43,10 +49,6 @@ struct OverlaidRootView: View {
             }
         }
         .environment(\.nowPlayingExpandProgress, nowPlayingExpandProgress)
-        .environment(\.expandNowPlaying) {
-            showOverlayingNowPlayng = true
-            expandedNowPlaying = true
-        }
     }
 
     func showNowPlayng(replacement: Bool) {

--- a/AppleMusicStylePlayer/OverlaidRootView.swift
+++ b/AppleMusicStylePlayer/OverlaidRootView.swift
@@ -43,6 +43,10 @@ struct OverlaidRootView: View {
             }
         }
         .environment(\.nowPlayingExpandProgress, nowPlayingExpandProgress)
+        .environment(\.expandNowPlaying) {
+            showOverlayingNowPlayng = true
+            expandedNowPlaying = true
+        }
     }
 
     func showNowPlayng(replacement: Bool) {


### PR DESCRIPTION
## Summary
- add environment key for expanding the Now Playing screen
- set `expandNowPlaying` action in `OverlaidRootView`
- use the new action and call `onPlayPause()` when tapping the Play button in `MediaListView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685e80a8b4f883299d617c21228b43fc