### PR TITLE
Fix overlay view visibility on first launch

### DIFF
--- a/AppleMusicStylePlayer/UI/UniversalOverlay.swift
+++ b/AppleMusicStylePlayer/UI/UniversalOverlay.swift
@@ -84,6 +84,11 @@ private struct UniversalOverlayModifier<ViewContent: View>: ViewModifier {
                     removeView()
                 }
             }
+            .onChange(of: properties.window != nil, initial: true) { _, newValue in
+                if newValue && show {
+                    addView()
+                }
+            }
     }
 
     private func addView() {


### PR DESCRIPTION
## Summary
- ensure universal overlay adds the view once its window exists

## Testing
- `swiftlint` *(fails: command not found)*
- `swiftformat --version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685e86b2c87c8329a0a94dcbec50d876