### PR TITLE
Add local track model and persistence

### DIFF
--- a/AppleMusicStylePlayer/Helpers/FileManager+Extensions.swift
+++ b/AppleMusicStylePlayer/Helpers/FileManager+Extensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension FileManager {
+    static var documentsDirectory: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+}

--- a/AppleMusicStylePlayer/MediaLibrary/Media.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/Media.swift
@@ -11,5 +11,7 @@ struct Media {
     let artwork: URL?
     let title: String
     let subtitle: String?
+    /// Local file URL for offline items
+    let fileURL: URL?
     let online: Bool
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
@@ -9,12 +9,38 @@ import Foundation
 
 final class MediaLibrary {
     var list: [MediaList]
+    private let storage = UserTracksStorage()
 
     init() {
-        list = [MockGTA5Radio().mediaList]
+        let tracks = storage.load()
+        if tracks.isEmpty {
+            list = [MockGTA5Radio().mediaList]
+        } else {
+            let items = tracks.map {
+                Media(
+                    artwork: $0.artworkURL,
+                    title: $0.title,
+                    subtitle: $0.artist,
+                    fileURL: $0.fileURL,
+                    online: false
+                )
+            }
+            list = [
+                MediaList(
+                    artwork: nil,
+                    title: "Your Tracks",
+                    subtitle: nil,
+                    items: items
+                )
+            ]
+        }
     }
 
     var isEmpty: Bool {
         !list.contains { !$0.items.isEmpty }
+    }
+
+    func save(_ tracks: [UserTrack]) {
+        storage.save(tracks)
     }
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
@@ -22,6 +22,7 @@ extension MockGTA5Radio {
                     artwork: stationImageUrl(String($0.logo.split(separator: ".")[0])),
                     title: $0.title,
                     subtitle: $0.genre,
+                    fileURL: nil,
                     online: false
                 )
             }

--- a/AppleMusicStylePlayer/MediaLibrary/UserTrack.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/UserTrack.swift
@@ -1,0 +1,43 @@
+import AVFoundation
+import Foundation
+
+struct UserTrack: Codable {
+    let fileName: String
+    var title: String
+    var artist: String?
+    var artworkFileName: String?
+
+    var fileURL: URL {
+        FileManager.documentsDirectory.appendingPathComponent(fileName)
+    }
+
+    var artworkURL: URL? {
+        artworkFileName.map { FileManager.documentsDirectory.appendingPathComponent($0) }
+    }
+
+    init(fileURL url: URL) {
+        self.fileName = url.lastPathComponent
+        self.title = url.deletingPathExtension().lastPathComponent
+        self.artist = nil
+        self.artworkFileName = nil
+
+        let asset = AVURLAsset(url: url)
+        for item in asset.commonMetadata {
+            guard let key = item.commonKey?.rawValue else { continue }
+            switch key {
+            case "title":
+                if let value = item.stringValue { self.title = value }
+            case "artist":
+                if let value = item.stringValue { self.artist = value }
+            case "artwork":
+                if let data = item.dataValue {
+                    let artworkName = UUID().uuidString + ".png"
+                    let dest = FileManager.documentsDirectory.appendingPathComponent(artworkName)
+                    try? data.write(to: dest)
+                    self.artworkFileName = artworkName
+                }
+            default: break
+            }
+        }
+    }
+}

--- a/AppleMusicStylePlayer/MediaLibrary/UserTracksStorage.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/UserTracksStorage.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct UserTracksStorage {
+    private let storeURL = FileManager.documentsDirectory.appendingPathComponent("tracks.json")
+
+    func load() -> [UserTrack] {
+        guard let data = try? Data(contentsOf: storeURL) else { return [] }
+        return (try? JSONDecoder().decode([UserTrack].self, from: data)) ?? []
+    }
+
+    func save(_ tracks: [UserTrack]) {
+        guard let data = try? JSONEncoder().encode(tracks) else { return }
+        try? data.write(to: storeURL)
+    }
+}

--- a/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
+++ b/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
@@ -149,6 +149,7 @@ private extension Media {
             artwork: nil,
             title: "---",
             subtitle: "---",
+            fileURL: nil,
             online: false
         )
     }


### PR DESCRIPTION
## Summary
- support file-based media by adding `fileURL` to `Media`
- load user imported tracks from `tracks.json` on startup
- persist imported track info in `UserTracksStorage`
- allow extraction of metadata from local audio via `UserTrack`
- expose documents directory via `FileManager` helper

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e96f78fc88329ad5c78c874963045