### PR TITLE
Add local media import

### DIFF
--- a/AppleMusicStylePlayer/MediaLibrary/LocalMediaLoader.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/LocalMediaLoader.swift
@@ -1,0 +1,51 @@
+import AVFoundation
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+
+@MainActor
+final class LocalMediaLoader: NSObject, UIDocumentPickerDelegate {
+    private var continuation: CheckedContinuation<[Media], Never>?
+
+    /// Presents document picker from provided controller and returns loaded media
+    func pick(from controller: UIViewController) async -> [Media] {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.audio])
+        picker.allowsMultipleSelection = true
+        picker.delegate = self
+        controller.present(picker, animated: true)
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        controller.dismiss(animated: true)
+        continuation?.resume(returning: loadMedia(from: urls))
+        continuation = nil
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        controller.dismiss(animated: true)
+        continuation?.resume(returning: [])
+        continuation = nil
+    }
+
+    /// Creates ``Media`` objects from file URLs using `AVAsset` metadata
+    func loadMedia(from urls: [URL]) -> [Media] {
+        urls.compactMap { url in
+            let asset = AVURLAsset(url: url)
+            let metadata = asset.commonMetadata
+
+            let title = metadata.first(where: { $0.commonKey == .commonKeyTitle })?.stringValue ?? url.deletingPathExtension().lastPathComponent
+            let artist = metadata.first(where: { $0.commonKey == .commonKeyArtist })?.stringValue
+            var artworkURL: URL?
+            if let data = metadata.first(where: { $0.commonKey == .commonKeyArtwork })?.dataValue {
+                let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".png")
+                try? data.write(to: tmp)
+                artworkURL = tmp
+            }
+
+            return Media(artwork: artworkURL, title: title, subtitle: artist, online: false, fileURL: url)
+        }
+    }
+}

--- a/AppleMusicStylePlayer/MediaLibrary/Media.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/Media.swift
@@ -12,4 +12,14 @@ struct Media {
     let title: String
     let subtitle: String?
     let online: Bool
+    /// Local file location for user imported media
+    let fileURL: URL?
+
+    init(artwork: URL?, title: String, subtitle: String?, online: Bool, fileURL: URL? = nil) {
+        self.artwork = artwork
+        self.title = title
+        self.subtitle = subtitle
+        self.online = online
+        self.fileURL = fileURL
+    }
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
@@ -6,15 +6,48 @@
 //
 
 import Foundation
+import UIKit
 
 final class MediaLibrary {
+    private let userTracksKey = "local-media-urls"
+    private let loader = LocalMediaLoader()
+
     var list: [MediaList]
 
     init() {
         list = [MockGTA5Radio().mediaList]
+
+        if let stored = UserDefaults.standard.array(forKey: userTracksKey) as? [String] {
+            let urls = stored.compactMap { URL(string: $0) }
+            let items = loader.loadMedia(from: urls)
+            if !items.isEmpty {
+                list.insert(MediaList(artwork: nil, title: "User Tracks", subtitle: nil, items: items), at: 0)
+            }
+        }
+    }
+
+    func pickUserTracks(from controller: UIViewController) async {
+        let items = await loader.pick(from: controller)
+        guard !items.isEmpty else { return }
+        addUserTracks(items)
     }
 
     var isEmpty: Bool {
         !list.contains { !$0.items.isEmpty }
+    }
+
+    /// Inserts new items into "User Tracks" list and persists them
+    func addUserTracks(_ items: [Media]) {
+        if let index = list.firstIndex(where: { $0.title == "User Tracks" }) {
+            var current = list[index]
+            current = MediaList(artwork: current.artwork, title: current.title, subtitle: current.subtitle, items: current.items + items)
+            list[index] = current
+        } else {
+            list.insert(MediaList(artwork: nil, title: "User Tracks", subtitle: nil, items: items), at: 0)
+        }
+
+        let urls = list.first(where: { $0.title == "User Tracks" })?.items.compactMap(\.fileURL)
+        let strings = urls?.map(\.absoluteString) ?? []
+        UserDefaults.standard.set(strings, forKey: userTracksKey)
     }
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
@@ -22,7 +22,8 @@ extension MockGTA5Radio {
                     artwork: stationImageUrl(String($0.logo.split(separator: ".")[0])),
                     title: $0.title,
                     subtitle: $0.genre,
-                    online: false
+                    online: false,
+                    fileURL: nil
                 )
             }
         )

--- a/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
+++ b/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
@@ -149,7 +149,8 @@ private extension Media {
             artwork: nil,
             title: "---",
             subtitle: "---",
-            online: false
+            online: false,
+            fileURL: nil
         )
     }
 }


### PR DESCRIPTION
## Summary
- extend `Media` with a `fileURL` property
- add `LocalMediaLoader` to load local audio files and parse metadata
- persist selected tracks in `MediaLibrary` and expose a picker helper
- adjust mock data and placeholders for the new property

## Testing
- `swiftformat --version` *(fails: command not found)*
- `swiftlint version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9f395a988329a31e6bc261b2051a