### PR TITLE
Display metadata in player

### DIFF
--- a/AppleMusicStylePlayer/MediaLibrary/LocalMediaLoader.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/LocalMediaLoader.swift
@@ -39,13 +39,22 @@ final class LocalMediaLoader: NSObject, UIDocumentPickerDelegate {
             let title = metadata.first(where: { $0.commonKey == .commonKeyTitle })?.stringValue ?? url.deletingPathExtension().lastPathComponent
             let artist = metadata.first(where: { $0.commonKey == .commonKeyArtist })?.stringValue
             var artworkURL: URL?
+            var artworkImage: UIImage?
             if let data = metadata.first(where: { $0.commonKey == .commonKeyArtwork })?.dataValue {
+                artworkImage = UIImage(data: data)
                 let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".png")
                 try? data.write(to: tmp)
                 artworkURL = tmp
             }
 
-            return Media(artwork: artworkURL, title: title, subtitle: artist, online: false, fileURL: url)
+            return Media(
+                artwork: artworkURL,
+                artworkImage: artworkImage,
+                title: title,
+                subtitle: artist,
+                online: false,
+                fileURL: url
+            )
         }
     }
 }

--- a/AppleMusicStylePlayer/MediaLibrary/Media.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/Media.swift
@@ -6,17 +6,28 @@
 //
 
 import Foundation
+import UIKit
 
 struct Media {
     let artwork: URL?
+    /// Embedded artwork image if available
+    let artworkImage: UIImage?
     let title: String
     let subtitle: String?
     let online: Bool
     /// Local file location for user imported media
     let fileURL: URL?
 
-    init(artwork: URL?, title: String, subtitle: String?, online: Bool, fileURL: URL? = nil) {
+    init(
+        artwork: URL? = nil,
+        artworkImage: UIImage? = nil,
+        title: String,
+        subtitle: String?,
+        online: Bool,
+        fileURL: URL? = nil
+    ) {
         self.artwork = artwork
+        self.artworkImage = artworkImage
         self.title = title
         self.subtitle = subtitle
         self.online = online

--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -7,6 +7,7 @@
 
 import Kingfisher
 import SwiftUI
+import UIKit
 
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
@@ -53,8 +54,7 @@ private extension MediaListView {
     var header: some View {
         VStack(spacing: 0) {
             let border = UIScreen.hairlineWidth
-            KFImage.url(model.display.artwork)
-                .resizable()
+            ArtworkImage(url: model.display.artwork, image: nil)
                 .aspectRatio(contentMode: .fill)
                 .background(Color(.palette.artworkBackground))
                 .clipShape(.rect(cornerRadius: 10))
@@ -109,6 +109,7 @@ private extension MediaListView {
                     }
                     MediaItemView(
                         artwork: item.artwork,
+                        artworkImage: item.artworkImage,
                         title: item.title,
                         subtitle: item.subtitle,
                         divider: isLastItem ? .long : .short
@@ -150,6 +151,7 @@ struct MediaItemView: View {
     }
 
     let artwork: URL?
+    let artworkImage: UIImage?
     let title: String
     let subtitle: String?
     let divider: DividerType
@@ -158,8 +160,7 @@ struct MediaItemView: View {
         VStack(spacing: 0) {
             HStack(spacing: 12) {
                 let border = UIScreen.hairlineWidth
-                KFImage.url(artwork)
-                    .resizable()
+                ArtworkImage(url: artwork, image: artworkImage)
                     .frame(width: 48, height: 48)
                     .aspectRatio(contentMode: .fill)
                     .background(Color(.palette.artworkBackground))

--- a/AppleMusicStylePlayer/NowPlaying/CompactNowPlaying.swift
+++ b/AppleMusicStylePlayer/NowPlaying/CompactNowPlaying.swift
@@ -7,6 +7,7 @@
 
 import Kingfisher
 import SwiftUI
+import UIKit
 
 struct CompactNowPlaying: View {
     @Environment(NowPlayingController.self) var model
@@ -68,8 +69,7 @@ private extension CompactNowPlaying {
     @ViewBuilder
     var artwork: some View {
         if !hideArtworkOnExpanded || !expanded {
-            KFImage.url(model.display.artwork)
-                .resizable()
+            ArtworkImage(url: model.display.artwork, image: model.display.artworkImage)
                 .aspectRatio(contentMode: .fill)
                 .background(Color(UIColor.systemGray4))
                 .clipShape(.rect(cornerRadius: 7))

--- a/AppleMusicStylePlayer/NowPlaying/RegularNowPlaying.swift
+++ b/AppleMusicStylePlayer/NowPlaying/RegularNowPlaying.swift
@@ -7,6 +7,7 @@
 
 import Kingfisher
 import SwiftUI
+import UIKit
 
 struct RegularNowPlaying: View {
     @Environment(NowPlayingController.self) var model
@@ -55,8 +56,7 @@ private extension RegularNowPlaying {
         GeometryReader {
             let size = $0.size
             let small = model.state == .paused
-            KFImage.url(model.display.artwork)
-                .resizable()
+            ArtworkImage(url: model.display.artwork, image: model.display.artworkImage)
                 .aspectRatio(contentMode: .fill)
                 .background(Color(UIColor.palette.playerCard.artworkBackground))
                 .clipShape(RoundedRectangle(cornerRadius: expanded ? 10 : 5, style: .continuous))

--- a/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
+++ b/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
@@ -125,10 +125,15 @@ private extension NowPlayingController {
     }
 
     func updateColors() {
+        if let image = display.artworkImage {
+            colors = image.dominantColorFrequencies(with: .high) ?? []
+            return
+        }
+
         guard let url = display.artwork else { return }
         Task { @MainActor in
             if let image = try? await KingfisherManager.shared.retrieveImage(with: url).image {
-                self.colors = (image.dominantColorFrequencies(with: .high) ?? [])
+                self.colors = image.dominantColorFrequencies(with: .high) ?? []
             }
         }
     }
@@ -147,6 +152,7 @@ private extension Media {
     static var placeholder: Self {
         Media(
             artwork: nil,
+            artworkImage: nil,
             title: "---",
             subtitle: "---",
             online: false,

--- a/AppleMusicStylePlayer/UI/Components/ArtworkImage.swift
+++ b/AppleMusicStylePlayer/UI/Components/ArtworkImage.swift
@@ -1,0 +1,31 @@
+import Kingfisher
+import SwiftUI
+
+struct ArtworkImage: View {
+    let url: URL?
+    let image: UIImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+            } else if let url {
+                KFImage.url(url)
+                    .resizable()
+                    .placeholder { fallback }
+            } else {
+                fallback
+            }
+        }
+    }
+
+    private var fallback: some View {
+        Image(systemName: "music.note")
+            .resizable()
+            .scaledToFit()
+            .padding(12)
+            .foregroundStyle(Color(.palette.artworkBorder))
+            .background(Color(.palette.artworkBackground))
+    }
+}


### PR DESCRIPTION
## Summary
- load artwork image data in `LocalMediaLoader`
- keep artwork `UIImage` reference in `Media`
- show fallback artwork with a new `ArtworkImage` component
- display loaded artwork in Now Playing and Media list views

## Testing
- `swiftformat .` *(fails: command not found)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea147f71c83298a8f0dd4a0def499