### PR TITLE
Add audio import and playback

### DIFF
--- a/AppleMusicStylePlayer/Helpers/AudioImporter.swift
+++ b/AppleMusicStylePlayer/Helpers/AudioImporter.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+
+struct AudioImporter: UIViewControllerRepresentable {
+    var onImport: ([URL]) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onImport: onImport)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.audio])
+        picker.allowsMultipleSelection = true
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onImport: ([URL]) -> Void
+        init(onImport: @escaping ([URL]) -> Void) {
+            self.onImport = onImport
+        }
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            onImport(urls)
+        }
+    }
+}
+

--- a/AppleMusicStylePlayer/MediaLibrary/Media.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/Media.swift
@@ -11,5 +11,7 @@ struct Media {
     let artwork: URL?
     let title: String
     let subtitle: String?
+    /// Source location of the audio file.
+    let url: URL
     let online: Bool
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
@@ -5,16 +5,58 @@
 //  Created by Alexey Vorobyov on 27.11.2024.
 //
 
+import AVFoundation
 import Foundation
+import UniformTypeIdentifiers
 
 final class MediaLibrary {
-    var list: [MediaList]
+    private let storageKey = "MediaLibrary.urls"
+    var list: [MediaList] = []
 
     init() {
-        list = [MockGTA5Radio().mediaList]
+        loadSaved()
     }
 
     var isEmpty: Bool {
         !list.contains { !$0.items.isEmpty }
+    }
+
+    func importFiles(_ urls: [URL]) {
+        var items = list.first?.items ?? []
+        urls.forEach { url in
+            if let media = metadata(for: url) {
+                items.append(media)
+            }
+        }
+        let newList = MediaList(artwork: nil, title: "Library", subtitle: nil, items: items)
+        list = [newList]
+        persist()
+    }
+
+    private func loadSaved() {
+        guard let stored = UserDefaults.standard.array(forKey: storageKey) as? [String] else { return }
+        let urls = stored.compactMap { URL(string: $0) }
+        importFiles(urls)
+    }
+
+    private func persist() {
+        guard let items = list.first?.items else { return }
+        let strings = items.map { $0.url.absoluteString }
+        UserDefaults.standard.set(strings, forKey: storageKey)
+    }
+
+    private func metadata(for url: URL) -> Media? {
+        let asset = AVURLAsset(url: url)
+        let meta = asset.commonMetadata
+        let title = meta.first(where: { $0.commonKey == .commonKeyTitle })?.stringValue ?? url.lastPathComponent
+        let artist = meta.first(where: { $0.commonKey == .commonKeyArtist })?.stringValue
+        var artworkURL: URL?
+        if let data = meta.first(where: { $0.commonKey == .commonKeyArtwork })?.dataValue {
+            let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            let imageURL = caches.appendingPathComponent(UUID().uuidString + ".png")
+            try? data.write(to: imageURL)
+            artworkURL = imageURL
+        }
+        return Media(artwork: artworkURL, title: title, subtitle: artist, url: url, online: false)
     }
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
@@ -22,6 +22,7 @@ extension MockGTA5Radio {
                     artwork: stationImageUrl(String($0.logo.split(separator: ".")[0])),
                     title: $0.title,
                     subtitle: $0.genre,
+                    url: URL(string: "https://example.com")!,
                     online: false
                 )
             }

--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
     @Environment(\.nowPlayingExpandProgress) var expandProgress
+    @State private var showImporter = false
 
     var body: some View {
         NavigationStack {
@@ -21,6 +22,15 @@ struct MediaListView: View {
             .contentMargins(.bottom, ViewConst.tabbarHeight, for: .scrollIndicators)
             .background(Color(.palette.appBackground(expandProgress: expandProgress)))
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        showImporter = true
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Color(.palette.brand))
+                    }
+                }
                 Button {
                     print("Profile tapped")
                 }
@@ -28,6 +38,11 @@ struct MediaListView: View {
                     Image(systemName: "person.crop.circle")
                         .font(.system(size: 20, weight: .semibold))
                         .foregroundStyle(Color(.palette.brand))
+                }
+            }
+            .sheet(isPresented: $showImporter) {
+                AudioImporter { urls in
+                    model.addTracks(urls: urls)
                 }
             }
         }

--- a/AppleMusicStylePlayer/MediaList/PlayListController.swift
+++ b/AppleMusicStylePlayer/MediaList/PlayListController.swift
@@ -32,6 +32,11 @@ class PlayListController {
     func selectFirstAvailable() {
         current = library.list.first { !$0.items.isEmpty }
     }
+
+    func addTracks(urls: [URL]) {
+        library.importFiles(urls)
+        selectFirstAvailable()
+    }
 }
 
 private extension MediaList {

--- a/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
+++ b/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
@@ -149,6 +149,7 @@ private extension Media {
             artwork: nil,
             title: "---",
             subtitle: "---",
+            url: URL(fileURLWithPath: "/dev/null"),
             online: false
         )
     }

--- a/AppleMusicStylePlayer/Player/Player.swift
+++ b/AppleMusicStylePlayer/Player/Player.swift
@@ -5,14 +5,26 @@
 //  Created by Alexey Vorobyov on 30.11.2024.
 //
 
+import AVFoundation
 import Foundation
 
 class Player {
+    private var audioPlayer: AVAudioPlayer?
+
     func play(_ media: Media) {
-        print("Play \(media.title)")
+        stop()
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: media.url)
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+            try AVAudioSession.sharedInstance().setActive(true)
+            audioPlayer?.play()
+        } catch {
+            print("Playback error: \(error)")
+        }
     }
 
     func stop() {
-        print("Stop")
+        audioPlayer?.stop()
+        audioPlayer = nil
     }
 }


### PR DESCRIPTION
## Summary
- enable selecting audio files via `AudioImporter`
- parse metadata for imported files and add them to `MediaLibrary`
- update player to use `AVAudioPlayer`
- allow `PlayListController` to add tracks
- show import button in `MediaListView`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685eaba537048329bc9d028217383b9e