### PR TITLE
Add local track importing

### DIFF
--- a/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
@@ -17,4 +17,24 @@ final class MediaLibrary {
     var isEmpty: Bool {
         !list.contains { !$0.items.isEmpty }
     }
+
+    func addMedia(from urls: [URL]) {
+        let media = urls.map { url in
+            Media(
+                artwork: nil,
+                title: url.deletingPathExtension().lastPathComponent,
+                subtitle: nil,
+                online: false
+            )
+        }
+
+        guard !media.isEmpty else { return }
+        let list = MediaList(
+            artwork: nil,
+            title: "Imported",
+            subtitle: nil,
+            items: media
+        )
+        self.list.append(list)
+    }
 }

--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -7,10 +7,12 @@
 
 import Kingfisher
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
     @Environment(\.nowPlayingExpandProgress) var expandProgress
+    @State private var showImporter = false
 
     var body: some View {
         NavigationStack {
@@ -21,13 +23,30 @@ struct MediaListView: View {
             .contentMargins(.bottom, ViewConst.tabbarHeight, for: .scrollIndicators)
             .background(Color(.palette.appBackground(expandProgress: expandProgress)))
             .toolbar {
-                Button {
-                    print("Profile tapped")
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button("Import") {
+                        showImporter = true
+                    }
+                    Button {
+                        print("Profile tapped")
+                    }
+                    label: {
+                        Image(systemName: "person.crop.circle")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Color(.palette.brand))
+                    }
                 }
-                label: {
-                    Image(systemName: "person.crop.circle")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(Color(.palette.brand))
+            }
+            .fileImporter(
+                isPresented: $showImporter,
+                allowedContentTypes: [.audio],
+                allowsMultipleSelection: true
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    model.importTracks(from: urls)
+                case .failure(let error):
+                    print(error.localizedDescription)
                 }
             }
         }

--- a/AppleMusicStylePlayer/MediaList/PlayListController.swift
+++ b/AppleMusicStylePlayer/MediaList/PlayListController.swift
@@ -12,6 +12,7 @@ import SwiftUI
 class PlayListController {
     var library = MediaLibrary()
     var current: MediaList?
+    private(set) var userTracks: [URL] = []
 
     init() {
         selectFirstAvailable()
@@ -31,6 +32,12 @@ class PlayListController {
 
     func selectFirstAvailable() {
         current = library.list.first { !$0.items.isEmpty }
+    }
+
+    func importTracks(from urls: [URL]) {
+        userTracks.append(contentsOf: urls)
+        library.addMedia(from: urls)
+        selectFirstAvailable()
     }
 }
 


### PR DESCRIPTION
## Summary
- extend `MediaLibrary` with `addMedia(from:)` for dynamic media creation
- track imported URLs in `PlayListController` and update media list
- add "Import" button in `MediaListView` using `fileImporter`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685eb56bf35c8329929d7f21af99ff1d