### PR TITLE
Add AVPlayer-based playback

### DIFF
--- a/AppleMusicStylePlayer/MediaLibrary/Media.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/Media.swift
@@ -11,5 +11,6 @@ struct Media {
     let artwork: URL?
     let title: String
     let subtitle: String?
+    let url: URL?
     let online: Bool
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
@@ -25,6 +25,7 @@ final class MediaLibrary {
                 artwork: nil,
                 title: url.deletingPathExtension().lastPathComponent,
                 subtitle: nil,
+                url: url,
                 online: false
             )
         }

--- a/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
+++ b/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
@@ -149,6 +149,7 @@ private extension Media {
             artwork: nil,
             title: "---",
             subtitle: "---",
+            url: nil,
             online: false
         )
     }

--- a/AppleMusicStylePlayer/Player/Player.swift
+++ b/AppleMusicStylePlayer/Player/Player.swift
@@ -5,14 +5,22 @@
 //  Created by Alexey Vorobyov on 30.11.2024.
 //
 
+import AVFoundation
 import Foundation
 
-class Player {
+final class Player {
+    private var player: AVPlayer?
+
     func play(_ media: Media) {
-        print("Play \(media.title)")
+        stop()
+        guard let url = media.url else { return }
+        let item = AVPlayerItem(url: url)
+        player = AVPlayer(playerItem: item)
+        player?.play()
     }
 
     func stop() {
-        print("Stop")
+        player?.pause()
+        player = nil
     }
 }


### PR DESCRIPTION
## Summary
- extend `Media` to store source URL
- persist URLs when importing media
- implement basic AVPlayer playback in `Player`
- update placeholder media definitions

## Testing
- `swiftformat` *(fails: command not found)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eba5d10b08329be22e6a72185cb58