### PR TITLE
Add selection API and list tap handling

### DIFF
--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct MediaListView: View {
     @Environment(PlayListController.self) var model
+    @Environment(NowPlayingController.self) var player
     @Environment(\.nowPlayingExpandProgress) var expandProgress
 
     var body: some View {
@@ -115,6 +116,9 @@ private extension MediaListView {
                     )
                 }
                 .padding(.leading, ViewConst.screenPaddings)
+                .onTapGesture {
+                    player.select(at: offset)
+                }
             }
         }
     }

--- a/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
+++ b/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
@@ -104,6 +104,12 @@ class NowPlayingController {
         self.currentIndex = prev
         updateColors()
     }
+
+    public func select(at index: Int) {
+        guard playList.items.indices.contains(index) else { return }
+        currentIndex = index
+        updateColors()
+    }
 }
 
 private extension NowPlayingController {


### PR DESCRIPTION
## Summary
- allow selecting a playlist item with `select(at:)`
- handle taps on media list rows to select items

## Testing
- `swiftlint version` *(fails: command not found)*
- `swiftformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fca6d54b883299c812e4c4491e2e1