### PR TITLE
Allow adding tracks from files

### DIFF
--- a/AppleMusicStylePlayer/MediaLibrary/Media.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/Media.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Media {
+struct Media: Codable {
     let artwork: URL?
     let title: String
     let subtitle: String?

--- a/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
@@ -7,14 +7,60 @@
 
 import Foundation
 
+private let userTracksTitle = "User Tracks"
+
 final class MediaLibrary {
+    private static let storageKey = "MediaLibrary.list"
     var list: [MediaList]
 
     init() {
-        list = [MockGTA5Radio().mediaList]
+        if let data = UserDefaults.standard.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode([MediaList].self, from: data) {
+            list = decoded
+        } else {
+            list = [MockGTA5Radio().mediaList]
+        }
     }
 
     var isEmpty: Bool {
         !list.contains { !$0.items.isEmpty }
+    }
+
+    func appendMedia(from urls: [URL]) {
+        let medias = urls.map { url in
+            Media(
+                artwork: nil,
+                title: url.lastPathComponent,
+                subtitle: nil,
+                online: false
+            )
+        }
+
+        if let index = list.firstIndex(where: { $0.title == userTracksTitle }) {
+            var userList = list[index]
+            userList = MediaList(
+                artwork: userList.artwork,
+                title: userList.title,
+                subtitle: userList.subtitle,
+                items: userList.items + medias
+            )
+            list[index] = userList
+        } else {
+            list.append(
+                MediaList(
+                    artwork: nil,
+                    title: userTracksTitle,
+                    subtitle: nil,
+                    items: medias
+                )
+            )
+        }
+        persist()
+    }
+
+    func persist() {
+        if let data = try? JSONEncoder().encode(list) {
+            UserDefaults.standard.set(data, forKey: Self.storageKey)
+        }
     }
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MediaList.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaList.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MediaList {
+struct MediaList: Codable {
     let artwork: URL?
     let title: String
     let subtitle: String?

--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -12,6 +12,7 @@ struct MediaListView: View {
     @Environment(PlayListController.self) var model
     @Environment(NowPlayingController.self) var player
     @Environment(\.nowPlayingExpandProgress) var expandProgress
+    @State private var showPicker = false
 
     var body: some View {
         NavigationStack {
@@ -30,6 +31,17 @@ struct MediaListView: View {
                         .font(.system(size: 20, weight: .semibold))
                         .foregroundStyle(Color(.palette.brand))
                 }
+
+                Button("Add Track") {
+                    showPicker = true
+                }
+            }
+        }
+        .sheet(isPresented: $showPicker) {
+            DocumentPicker { urls in
+                model.library.appendMedia(from: urls)
+                model.selectFirstAvailable()
+                showPicker = false
             }
         }
     }

--- a/AppleMusicStylePlayer/MediaList/PlayListController.swift
+++ b/AppleMusicStylePlayer/MediaList/PlayListController.swift
@@ -30,7 +30,12 @@ class PlayListController {
     }
 
     func selectFirstAvailable() {
-        current = library.list.first { !$0.items.isEmpty }
+        if let cur = current,
+           let updated = library.list.first(where: { $0.title == cur.title }) {
+            current = updated
+        } else {
+            current = library.list.first { !$0.items.isEmpty }
+        }
     }
 }
 

--- a/AppleMusicStylePlayer/UI/Components/DocumentPicker.swift
+++ b/AppleMusicStylePlayer/UI/Components/DocumentPicker.swift
@@ -1,0 +1,37 @@
+//
+//  DocumentPicker.swift
+//  AppleMusicStylePlayer
+//
+//  Created by OpenAI Codex on 2025.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    var onPick: ([URL]) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPick: onPick)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.audio])
+        picker.allowsMultipleSelection = true
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_: UIDocumentPickerViewController, context _: Context) {}
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onPick: ([URL]) -> Void
+        init(onPick: @escaping ([URL]) -> Void) {
+            self.onPick = onPick
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            onPick(urls)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make `Media` and `MediaList` codable
- persist `MediaLibrary` and load from `UserDefaults`
- add `appendMedia` helper for loading media from URLs
- integrate a new `DocumentPicker` for choosing audio files
- support adding tracks through an "Add Track" button
- refresh playlist selection when library updates

## Testing
- `swift -version`

------
https://chatgpt.com/codex/tasks/task_e_685fcd517bf48329bf1b30f0aadffb60