### PR TITLE
Enable adding tracks from files

### DIFF
--- a/AppleMusicStylePlayer/DocumentPicker/FilePicker.swift
+++ b/AppleMusicStylePlayer/DocumentPicker/FilePicker.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FilePicker: UIViewControllerRepresentable {
+    typealias Callback = ([URL]) -> Void
+    var onPick: Callback
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPick: onPick)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let controller = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.audio])
+        controller.allowsMultipleSelection = true
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onPick: Callback
+        init(onPick: @escaping Callback) { self.onPick = onPick }
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            onPick(urls)
+        }
+    }
+}

--- a/AppleMusicStylePlayer/MediaLibrary/Media.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/Media.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 
-struct Media {
+struct Media: Codable {
     let artwork: URL?
     let title: String
     let subtitle: String?
     let online: Bool
+    let fileURL: URL?
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaLibrary.swift
@@ -8,13 +8,46 @@
 import Foundation
 
 final class MediaLibrary {
+    private let storageKey = "MediaLibrary.list"
     var list: [MediaList]
 
     init() {
-        list = [MockGTA5Radio().mediaList]
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode([MediaList].self, from: data) {
+            list = decoded
+        } else {
+            list = [MediaList(artwork: nil, title: "Library", subtitle: nil, items: [])]
+        }
     }
 
     var isEmpty: Bool {
         !list.contains { !$0.items.isEmpty }
+    }
+
+    func append(from urls: [URL]) {
+        guard !urls.isEmpty else { return }
+
+        if list.isEmpty {
+            list.append(MediaList(artwork: nil, title: "Library", subtitle: nil, items: []))
+        }
+
+        var first = list[0]
+        first.items.append(contentsOf: urls.map { url in
+            Media(
+                artwork: nil,
+                title: url.deletingPathExtension().lastPathComponent,
+                subtitle: nil,
+                online: false,
+                fileURL: url
+            )
+        })
+        list[0] = first
+        save()
+    }
+
+    private func save() {
+        if let data = try? JSONEncoder().encode(list) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
     }
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MediaList.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MediaList.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-struct MediaList {
-    let artwork: URL?
-    let title: String
-    let subtitle: String?
-    let items: [Media]
+struct MediaList: Codable {
+    var artwork: URL?
+    var title: String
+    var subtitle: String?
+    var items: [Media]
 }

--- a/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
+++ b/AppleMusicStylePlayer/MediaLibrary/MockGTA5Radiostations.swift
@@ -22,7 +22,8 @@ extension MockGTA5Radio {
                     artwork: stationImageUrl(String($0.logo.split(separator: ".")[0])),
                     title: $0.title,
                     subtitle: $0.genre,
-                    online: false
+                    online: false,
+                    fileURL: nil
                 )
             }
         )

--- a/AppleMusicStylePlayer/MediaList/MediaListView.swift
+++ b/AppleMusicStylePlayer/MediaList/MediaListView.swift
@@ -12,6 +12,7 @@ struct MediaListView: View {
     @Environment(PlayListController.self) var model
     @Environment(NowPlayingController.self) var player
     @Environment(\.nowPlayingExpandProgress) var expandProgress
+    @State private var showPicker = false
 
     var body: some View {
         NavigationStack {
@@ -22,13 +23,28 @@ struct MediaListView: View {
             .contentMargins(.bottom, ViewConst.tabbarHeight, for: .scrollIndicators)
             .background(Color(.palette.appBackground(expandProgress: expandProgress)))
             .toolbar {
-                Button {
-                    print("Profile tapped")
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showPicker = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
                 }
-                label: {
-                    Image(systemName: "person.crop.circle")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(Color(.palette.brand))
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        print("Profile tapped")
+                    } label: {
+                        Image(systemName: "person.crop.circle")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Color(.palette.brand))
+                    }
+                }
+            }
+            .sheet(isPresented: $showPicker) {
+                FilePicker { urls in
+                    model.library.append(from: urls)
+                    model.selectFirstAvailable()
+                    showPicker = false
                 }
             }
         }

--- a/AppleMusicStylePlayer/MediaList/PlayListController.swift
+++ b/AppleMusicStylePlayer/MediaList/PlayListController.swift
@@ -30,7 +30,7 @@ class PlayListController {
     }
 
     func selectFirstAvailable() {
-        current = library.list.first { !$0.items.isEmpty }
+        current = library.list.first { !$0.items.isEmpty } ?? current
     }
 }
 

--- a/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
+++ b/AppleMusicStylePlayer/NowPlayingController/NowPlayingController.swift
@@ -155,7 +155,8 @@ private extension Media {
             artwork: nil,
             title: "---",
             subtitle: "---",
-            online: false
+            online: false,
+            fileURL: nil
         )
     }
 }


### PR DESCRIPTION
## Summary
- define a `FilePicker` wrapper around `UIDocumentPickerViewController`
- store media in `MediaLibrary` using `UserDefaults`
- expand `Media`/`MediaList` models for persistence
- show an `Add Track` button in `MediaListView` and append selected files
- keep playlist selection in sync with the library

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685fcfc950c08329971c1bb94ad3eaa7