### PR TITLE
Add playback progress tracking

### DIFF
--- a/AppleMusicStylePlayer/NowPlaying/PlayerControls/PlayerControls.swift
+++ b/AppleMusicStylePlayer/NowPlaying/PlayerControls/PlayerControls.swift
@@ -19,7 +19,14 @@ struct PlayerControls: View {
                 VStack(spacing: spacing) {
                     trackInfo
                     let indicatorPadding = ViewConst.playerCardPaddings - ElasticSliderConfig.playbackProgress.growth
-                    TimingIndicator(spacing: spacing)
+                    TimingIndicator(
+                        spacing: spacing,
+                        progress: Binding(
+                            get: { model.progress },
+                            set: { model.seek(to: $0) }
+                        ),
+                        duration: model.duration
+                    )
                         .padding(.top, spacing)
                         .padding(.horizontal, indicatorPadding)
                 }

--- a/AppleMusicStylePlayer/NowPlaying/PlayerControls/TimingIndicator.swift
+++ b/AppleMusicStylePlayer/NowPlaying/PlayerControls/TimingIndicator.swift
@@ -9,8 +9,10 @@ import SwiftUI
 
 struct TimingIndicator: View {
     let spacing: CGFloat
-    @State var progress: Double = 60
-    let range = 0.0 ... 194
+    @Binding var progress: Double
+    let duration: Double
+
+    private var range: ClosedRange<Double> { 0 ... duration }
 
     var body: some View {
         ElasticSlider(
@@ -64,10 +66,15 @@ extension ElasticSliderConfig {
 }
 
 #Preview {
+    @State var progress: Double = 60
     ZStack {
         PreviewBackground()
-        TimingIndicator(spacing: 10)
-            .padding(.horizontal)
+        TimingIndicator(
+            spacing: 10,
+            progress: $progress,
+            duration: 194
+        )
+        .padding(.horizontal)
     }
 }
 

--- a/AppleMusicStylePlayer/Player/Player.swift
+++ b/AppleMusicStylePlayer/Player/Player.swift
@@ -56,4 +56,16 @@ class Player {
         player = nil
         currentURL = nil
     }
+
+    var currentTime: TimeInterval {
+        get { player?.currentTime ?? storedTime }
+        set {
+            storedTime = newValue
+            player?.currentTime = newValue
+        }
+    }
+
+    var duration: TimeInterval {
+        player?.duration ?? 0
+    }
 }


### PR DESCRIPTION
## Summary
- hook up `TimingIndicator` to the player's playback position
- expose `currentTime` and `duration` in `Player`
- maintain and update progress in `NowPlayingController`
- allow seeking through the progress bar

## Testing
- `swift --version`
- `sudo apt-get update`
- `sudo apt-get install -y swiftformat` *(fails: package not found)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff9cfaa188329a059c66dfec71a20